### PR TITLE
added debug sdk target

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This app builder can create a new space for you, setting up necessary structures
   not checked into version control.
   * package.json: This file lists the dependencies for grunt
 
-#Installing
+# Installing
 
 1.  **Install node.js**  This really is as simple as going to node[node] 
 and pushing the Install button.  Afterward, type this command to see that 
@@ -40,7 +40,7 @@ sudo as shown below. On Windows, you will not use the sudo part of the command.
 3.  **Install template** The easiest thing is to install this template to 
   your home directory:
     
-    git clone https://github.com/RallyTechServices/ts-app-builder.git ~/.grunt-init/ts-app-builder
+    `git clone https://github.com/RallyTechServices/ts-app-builder.git ~/.grunt-init/ts-app-builder`
 
   _(Windows users, see [the documentation][grunt-init] for the correct destination directory path)_
 
@@ -49,18 +49,18 @@ sudo as shown below. On Windows, you will not use the sudo part of the command.
 When 1-3 are done, you can do this step in as many different places as you like.
 
 Create a new directory for your app, cd into that directory, then type:
-
+```
     grunt-init ts-app-builder
-
+```
 You'll be prompted for some default values.  You can change them in the resulting config.json and auth.json files. 
 
 After the prompt comes back, do a local install of the required npm libraries by typing (ignore warnings about missing repositories):
-
+```
     npm install
-    
+``` 
 After install is complete, you should be able to run the fast tests and get intentional failures.
 Something like this:
-
+```
     Running "jasmine:fast" (jasmine) task
     Testing jasmine specs via phantom
     x.
@@ -69,14 +69,28 @@ Something like this:
     2 specs in 0.002s.
     >> 1 failures
     Warning: Task "jasmine:fast" failed. Use --force to continue.
-
+```
 Another check:  You should be able to compile the debug version and view it (after logging in to Rally) 
 in a new tab.  
-
+```
     grunt debug
+```
+
+# Usage of NPM scripts
+
+NPM scripts have been created to make it easier to watch for changes and re-run grunt tasks. For a list of options, see `package.json` or run `npm run`.
+For example `npm run deploy-debugsdk:watch` will watch for code changes and re-deploy an unminified version with the debug SDK to allow easy in-browser
+debugging of the app or the SDK itself.
 
 # Usage of the grunt file
-##Tasks
+## Tasks
+
+### grunt deploy, deploy-pretty, deploy-debugsdk
+
+Creates the application HTML file and deploys it to the account configured in `auth.json`.
+* `deploy` - deploys a minified version
+* `deploy-pretty` - deploys an unminified version which allows in-browser debugging
+* `deploy-debugsdk` - deploys and unminified version that uses the debug SDK to allow breakpoints in the app code OR the SDK
     
 ### grunt debug
 

--- a/root/Gruntfile.js
+++ b/root/Gruntfile.js
@@ -70,6 +70,13 @@ module.exports = function(grunt) {
                     variables: config
                 },
 
+                debugsdk: {
+                    src: 'templates/App-debugsdk-tpl.html',
+                    dest: 'deploy/App.txt',
+                    engine: 'underscore',
+                    variables: config
+                },
+
                 prod: {
                     src: 'templates/App-tpl.html',
                     dest: 'deploy/App.txt',
@@ -221,7 +228,6 @@ module.exports = function(grunt) {
         request.defaults({jar: j});
 
         var installApp = function(page_oid,panel_oid) {
-            // DEFAULT TO ugly for deploying
             var html = grunt.file.read(deploy_file_name);
 
             var uri = config.auth.server + "/slm/dashboard/changepanelsettings.sp";
@@ -408,4 +414,6 @@ module.exports = function(grunt) {
     grunt.registerTask('deploy', 'Build and deploy app to the location in auth.json',['ugly','install:deploy/Ugly.txt']);
 
     grunt.registerTask('deploy-pretty', 'Build and deploy app to the location in auth.json',['pretty','install:deploy/App.txt']);
+
+    grunt.registerTask('deploy-debugsdk', 'Build and deploy app to the location in auth.json',['template:debugsdk', 'setPostBuildInfo:deploy/App.txt', 'install:deploy/App.txt']);
 };

--- a/root/package.json
+++ b/root/package.json
@@ -2,18 +2,26 @@
   "_comment": "This file is used by grunt",
   "name": "tsabc",
   "version": "0.2.0",
+  "scripts": {
+    "debug": "grunt debug",
+    "debug:watch": "nodemon --exec grunt debug",
+    "deploy:watch": "nodemon --exec grunt deploy",
+    "deploy-pretty:watch": "nodemon --exec grunt deploy-pretty",
+    "deploy-debugsdk:watch": "nodemon --exec grunt deploy-debugsdk"
+  },
   "dependencies": {},
   "devDependencies": {
     "grunt": "~1.0.1",
     "grunt-cli": "1.2.0",
     "grunt-contrib-jasmine": "1.1.0",
-    "grunt-templater": "git://github.com/rockwood/grunt-templater.git",
-    "underscore": "1.8.3",
+    "grunt-contrib-uglify": "0.3.2",
+    "grunt-contrib-watch": "1.0.0",
     "grunt-prompt": "^1.3.3",
-    "grunt-contrib-uglify":"0.3.2",
-    "request":"2.67",
-    "grunt-contrib-watch":"1.0.0",
-    "username":"2.1.0",
-    "rally-sdk2-test-utils": "0.1.2"
+    "grunt-templater": "git://github.com/rockwood/grunt-templater.git",
+    "nodemon": "^1.14.11",
+    "rally-sdk2-test-utils": "0.1.2",
+    "request": "2.67",
+    "underscore": "1.8.3",
+    "username": "2.1.0"
   }
 }

--- a/root/templates/App-debugsdk-tpl.html
+++ b/root/templates/App-debugsdk-tpl.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>CATS-
+        <%= name %>-
+            <%= version %>
+    </title>
+    <!--  (c) 2017 CA Technologies.  All Rights Reserved. -->
+    <!--  Build Date: <%= new Date() %> -->
+
+    <script type="text/javascript">
+        var APP_BUILD_DATE = "<%= new Date() %>";
+        var ARTIFACT = "<%= artifact %>";
+        var BUILDER = "[%= builder %]";
+        var CHECKSUM = "[%= checksum %]";
+    </script>
+
+    <script type="text/javascript" src="<%= auth.server %>/apps/<%= sdk %>/sdk-debug.js"></script>
+    <!-- our highcharts (needed so that we can add patterns)
+    <script type="text/javascript" src="/apps/<%= sdk %>/lib/analytics/analytics-all.js"></script>
+    -->
+
+
+    <script type="text/javascript">
+        Rally.onReady(function() {
+            <%= js_contents %>
+
+            Rally.launchApp('<%= className %>', {
+                name: '<%= name %>'
+            });
+        });
+    </script>
+
+    <style type="text/css">
+        <%=style_contents %>
+    </style>
+
+</head>
+
+<body></body>
+
+</html>


### PR DESCRIPTION
Summary
* Added a debug SDK deployment to allow for easier app debugging of app AND the SDK itself
* Added NPM helper scripts to allow for other kinds of file watch targets because grunt only supports 1 watch target